### PR TITLE
Steam tools/runtime search update

### DIFF
--- a/src/protontricks/cli.py
+++ b/src/protontricks/cli.py
@@ -13,6 +13,7 @@ import argparse
 import shutil
 import subprocess
 import os
+import shlex
 import logging
 
 from . import __version__
@@ -113,7 +114,7 @@ def main():
     enable_logging(args.verbose)
 
     # 1. Find Steam path
-    steam_path = find_steam_path()
+    steam_path, steam_root = find_steam_path()
     if not steam_path:
         print(
             "Steam installation directory could not be found."
@@ -133,7 +134,7 @@ def main():
     steam_lib_paths = get_steam_lib_paths(steam_path)
 
     # 4. Find any Steam apps
-    steam_apps = get_steam_apps(steam_path, steam_lib_paths)
+    steam_apps = get_steam_apps(steam_root, steam_lib_paths)
 
     # 5. Find active Proton version
     proton_app = find_proton_app(
@@ -148,7 +149,7 @@ def main():
         if args.runtime:
             runtime_cmd = [
                 os.path.join(
-                    steam_path, "ubuntu12_32", "steam-runtime", "run.sh")
+                    steam_root, "ubuntu12_32", "steam-runtime", "run.sh")
             ]
         else:
             runtime_cmd = []
@@ -217,7 +218,7 @@ def main():
         if args.runtime:
             runtime_cmd = [
                 os.path.join(
-                    steam_path, "ubuntu12_32", "steam-runtime", "run.sh")
+                    steam_root, "ubuntu12_32", "steam-runtime", "run.sh")
             ]
         else:
             runtime_cmd = []
@@ -232,8 +233,7 @@ def main():
         if args.runtime:
             runtime_cmd = "'{}' ".format(
                 os.path.join(
-                    steam_path, "ubuntu12_32", "steam-runtime", "run.sh"
-                )
+                    steam_root, "ubuntu12_32", "steam-runtime", "run.sh")
             )
         else:
             runtime_cmd = ""

--- a/src/protontricks/cli.py
+++ b/src/protontricks/cli.py
@@ -15,13 +15,13 @@ import subprocess
 import os
 import logging
 
-from protontricks import __version__
-from protontricks.steam import (find_proton_app, find_steam_path,
+from . import __version__
+from .steam import (find_proton_app, find_steam_path,
                                 get_steam_apps, get_steam_lib_paths,
                                 get_custom_proton_installations)
-from protontricks.winetricks import get_winetricks_path
-from protontricks.gui import select_steam_app_with_gui
-from protontricks.util import run_command
+from .winetricks import get_winetricks_path
+from .gui import select_steam_app_with_gui
+from .util import run_command
 
 logger = logging.getLogger("protontricks")
 

--- a/src/protontricks/util.py
+++ b/src/protontricks/util.py
@@ -47,6 +47,7 @@ def run_command(
     # Unset WINEARCH, which might be set for another Wine installation
     os.environ.pop("WINEARCH", "")
 
+    logger.info("Attempting to run sp.call::{command}".format(command=command))
     try:
         subprocess.call(command, **kwargs)
     finally:

--- a/src/protontricks/winetricks.py
+++ b/src/protontricks/winetricks.py
@@ -4,7 +4,7 @@ import shutil
 import subprocess
 import sys
 
-from protontricks.util import run_command
+from .util import run_command
 
 __all__ = ("get_winetricks_path",)
 


### PR DESCRIPTION
Per my notes on #4, some tweaks on how finding steam things works. Mostly a "try and see if it exists, if not, use old paths and hope"

Note: since I have a hatred for needing to reinstall locally via pip every time I changed a line of code, have some relative import fixes too.

Based on the steam_runtime branch because on kubuntu 18.04 with no wine installed I required steam-runtime to do anything proton related. If you really want me to rebase off master let me know.