### PR TITLE
Workaround mixed-case appid keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
  - Use the correct Proton installation when selecting a Steam app using the GUI.
  - Print a proper error message if Steam isn't found.
  - Print an error message when GUI is enabled and no games were found.
+ - Support appmanifest files with mixed case field names.
 
 ## [1.2] - 2019-02-27
 ### Added

--- a/src/protontricks/steam.py
+++ b/src/protontricks/steam.py
@@ -115,6 +115,9 @@ class SteamApp(object):
             logger.info("Skipping empty appmanifest {}".format(path))
             return None
 
+        # Some games use mixed case appid (e.g., Anomaly Korea and Cogs use appID),
+        # work around this by converting all keys to lower case.
+        app_state = {k.lower():v for k,v in app_state.items()}
         appid = int(app_state["appid"])
         name = app_state["name"]
         prefix_path = os.path.join(

--- a/src/protontricks/steam.py
+++ b/src/protontricks/steam.py
@@ -115,9 +115,12 @@ class SteamApp(object):
             logger.info("Skipping empty appmanifest {}".format(path))
             return None
 
-        # Some games use mixed case appid (e.g., Anomaly Korea and Cogs use appID),
-        # work around this by converting all keys to lower case.
-        app_state = {k.lower():v for k,v in app_state.items()}
+        # The app ID field can be named 'appID' or 'appid'.
+        # 'appid' is more common, but certain appmanifest
+        # files (created by old Steam clients?) also use 'appID'.
+        #
+        # Use case-insensitive field names to deal with these.
+        app_state = {k.lower(): v for k, v in app_state.items()}
         appid = int(app_state["appid"])
         name = app_state["name"]
         prefix_path = os.path.join(


### PR DESCRIPTION
Some games use mixed case appid (e.g., Anomaly Korea and Cogs use appID), work around this by converting all keys to lower case.