### PR TITLE
Allow running commands in $WINEPREFIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ protontricks --gui
 
 # Print the protontricks help message
 protontricks --help
+
+# Run a command in a WINEPREFIX with Proton
+WINEPREFIX="<prefix_path>" protontricks -c <command>
 ```
 
 Since this is a wrapper, all commands that work for Winetricks will likely work for Protontricks as well.

--- a/src/protontricks/cli.py
+++ b/src/protontricks/cli.py
@@ -230,6 +230,20 @@ def main():
         print("Proton installation could not be found!")
         sys.exit(-1)
 
+    # Run command in WINEPREFIX when appid is not set.
+    # If WINEPREFIX is not set a sane default will be chosen
+    if not args.appid:
+      if args.command:
+        run_command(
+            steam_path=steam_path,
+            winetricks_path=winetricks_path,
+            proton_app=proton_app,
+            steam_app=None,
+            command=args.command,
+            steam_runtime_path=steam_runtime_path,
+            shell=True)
+        return
+
     # If neither search or GUI are set, do a normal Winetricks command
     # Find game by appid
     steam_appid = int(args.appid)

--- a/src/protontricks/util.py
+++ b/src/protontricks/util.py
@@ -58,8 +58,21 @@ def run_command(
             proton_app.install_path, "dist", "bin", "wineserver"
         )
 
+    if steam_app:
+        os.environ["WINEPREFIX"] = steam_app.prefix_path
+    else:
+        # Use already set WINEPREFIX or sane default if we're running without
+        # an appid
+        os.environ["WINEPREFIX"] = os.environ.get(
+            "WINEPREFIX", os.path.join(os.environ.get(
+                "XDG_DATA_DIR", os.path.join(
+                    os.environ.get("HOME"), ".local", "share")),
+                    "protontricks"))
+        if not os.path.exists(os.environ["WINEPREFIX"]):
+            os.makedirs(os.environ["WINEPREFIX"])
+        logger.info("WINEPREFIX: {0}".format(os.environ["WINEPREFIX"]))
+
     os.environ["WINETRICKS"] = winetricks_path
-    os.environ["WINEPREFIX"] = steam_app.prefix_path
     os.environ["WINELOADER"] = os.environ["WINE"]
     os.environ["WINEDLLPATH"] = "".join([
         os.path.join(proton_app.install_path, "dist", "lib64", "wine"),


### PR DESCRIPTION
This adds the possibility to run custom commands inside the proton environment. This is useful to prevent the command to be run in the system wine environment and use the proton environment instead.

While running a command without protontricks wine updates the prefix while proton downgrades it at the next start.

Using protontricks with the command prevents this behavior and no unnecessary upgrades or downgrades are being done.

With a command and without an appid protontricks uses `WINEPREFIX` as prefix. If it's not set it will default to `$XDG_DATA_DIR/protontricks` which by itself defaults to `$HOME/.local/share/protontricks`.