### PR TITLE
Fix zenity error for games with Unicode symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+### Fixed
+ - Zenity no longer crashes the script if locale is incapable of processing the arguments.
+ - Selecting "Cancel" in the GUI window now prints a proper message instead of an error.
+
 ## [1.3.1] - 2019-11-21
 ### Fixed
  - Fix Proton prefix detection when the prefix directory is located inside a `SteamApps` directory instead of `steamapps`

--- a/src/protontricks/gui.py
+++ b/src/protontricks/gui.py
@@ -14,10 +14,12 @@ def select_steam_app_with_gui(steam_apps):
 
     Return the selected SteamApp
     """
+    # '.encode' fixes zenity crash on systems with non-en_US locales
+    # 'ignore' argument removes unicode characters
     combo_values = "|".join([
         '{}: {}'.format(app.name, app.appid) for app in steam_apps
         if app.prefix_path_exists and app.appid
-    ])
+    ]).encode('ascii', 'ignore')
 
     try:
         result = run([
@@ -36,9 +38,13 @@ def select_steam_app_with_gui(steam_apps):
         # Related issues:
         # https://github.com/Matoking/protontricks/issues/20
         # https://gitlab.gnome.org/GNOME/zenity/issues/7
+        #
+        # 'exc.returncode == 1' avoids zenity error when
+        # no game is selected
         is_zenity_bug = (
-            exc.returncode == -6 and
-            exc.stderr == b'free(): double free detected in tcache 2\n'
+            (exc.returncode == -6 and
+            exc.stderr == b'free(): double free detected in tcache 2\n') or
+            exc.returncode == 1
         )
 
         if is_zenity_bug:

--- a/src/protontricks/gui.py
+++ b/src/protontricks/gui.py
@@ -7,6 +7,10 @@ __all__ = ("select_steam_app_with_gui",)
 logger = logging.getLogger("protontricks")
 
 
+class LocaleError(Exception):
+    pass
+
+
 def select_steam_app_with_gui(steam_apps):
     """
     Prompt the user to select a Proton-enabled Steam app from
@@ -14,19 +18,53 @@ def select_steam_app_with_gui(steam_apps):
 
     Return the selected SteamApp
     """
-    # '.encode' fixes zenity crash on systems with non-en_US locales
-    # 'ignore' argument removes unicode characters
+    def run_zenity(args, strip_nonascii=False):
+        """
+        Run Zenity with the given args.
+
+        If 'strip_nonascii' is True, strip non-ASCII characters to workaround
+        environments that can't handle all characters
+        """
+        if strip_nonascii:
+            # Convert to bytes and back to strings while stripping
+            # non-ASCII characters
+            args = [
+                arg.encode("ascii", "ignore").decode("ascii") for arg in args
+            ]
+
+        try:
+            return run(args, check=True, stdout=PIPE, stderr=PIPE)
+        except CalledProcessError as exc:
+            if exc.returncode == 255:
+                # User locale incapable of handling all characters in the
+                # command
+                raise LocaleError()
+
+            raise
+
     combo_values = "|".join([
         '{}: {}'.format(app.name, app.appid) for app in steam_apps
         if app.prefix_path_exists and app.appid
-    ]).encode('ascii', 'ignore')
+    ])
+    args = [
+        "zenity", "--forms", "--text=Steam Game Library",
+        "--title=Choose Game", "--add-combo", "Pick a library game",
+        "--combo-values", combo_values
+    ]
 
     try:
-        result = run([
-            'zenity', '--forms', '--text=Steam Game Library',
-            '--title=Choose Game', '--add-combo', 'Pick a library game',
-            '--combo-values', combo_values
-        ], check=True, stdout=PIPE, stderr=PIPE)
+        try:
+            result = run_zenity(args)
+        except LocaleError:
+            # User has weird locale settings. Log a warning and
+            # run the command while stripping non-ASCII characters.
+            logger.warning(
+                "Your system locale is incapable of displaying all "
+                "characters. Some app names may not show up correctly. "
+                "Please use an UTF-8 locale to avoid this warning."
+            )
+            result = run_zenity(args, strip_nonascii=True)
+
         choice = result.stdout
     except CalledProcessError as exc:
         # TODO: Remove this hack once the bug has been fixed upstream

--- a/src/protontricks/gui.py
+++ b/src/protontricks/gui.py
@@ -42,8 +42,10 @@ def select_steam_app_with_gui(steam_apps):
         # 'exc.returncode == 1' avoids zenity error when
         # no game is selected
         is_zenity_bug = (
-            (exc.returncode == -6 and
-            exc.stderr == b'free(): double free detected in tcache 2\n') or
+            (
+                exc.returncode == -6 and
+                exc.stderr == b'free(): double free detected in tcache 2\n'
+            ) or
             exc.returncode == 1
         )
 


### PR DESCRIPTION
Fixes an error with zenity causing CalledProcessError to return 255 on
systems with odd locales. Should fix #31.

Fixes issue where program would incorrectly raise RuntimeError for
zenity when no game was selected, instead of printing that no game was
selected.