### PR TITLE
Don't specify that this requires Steam beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a simple wrapper script that allows you to easily run Winetricks command
 
 * Python 3.5 or newer
 * Winetricks
-* Steam Client Beta (comes with Proton)
+* Steam
 
 # Usage
 


### PR DESCRIPTION
Steam now allows the use of Proton in the "stable" Steam branch, so this should be updated to specify that you only need Steam (rather than a specific branch of it).