### PR TITLE
Fix typo in content_rating metainfo

### DIFF
--- a/data/com.github.Matoking.protontricks.metainfo.xml
+++ b/data/com.github.Matoking.protontricks.metainfo.xml
@@ -12,7 +12,7 @@
       <caption>App selection screen</caption>
     </screenshot>
   </screenshots>
-  <content_rating type="oais-1.1"/>
+  <content_rating type="oars-1.1"/>
   <description>
     <p>A simple wrapper that does winetricks things for Proton enabled games.</p>
   </description>


### PR DESCRIPTION
protontricks has a content rating type that is not known to Flatpak. This causes Flatpak to assume the application has adult or otherwise controversial content (because it can't understand the content rating), which makes it present a "parental controls" prompt when installing protontricks.

oais-1.1 was presumably a typo for oars-1.1, which is supported. An empty oars-1.1 rating means there is nothing in the application that is considered adult or otherwise controversial.