### PR TITLE
Fix metainfo warnings

### DIFF
--- a/data/com.github.Matoking.protontricks.metainfo.xml
+++ b/data/com.github.Matoking.protontricks.metainfo.xml
@@ -8,6 +8,7 @@
   <icon type="stock">wine</icon>
   <provides>
     <binary>protontricks</binary>
+    <binary>protontricks-launch</binary>
   </provides>
   <recommends>com.valvesoftware.Steam</recommends>
   <screenshots>

--- a/data/com.github.Matoking.protontricks.metainfo.xml
+++ b/data/com.github.Matoking.protontricks.metainfo.xml
@@ -18,7 +18,7 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <description>
-    <p>This is a wrapper script that allows you to easily run Winetricks commandsfor Steam Play/Proton games among other common Wine features,
+    <p>This is a wrapper script that allows you to easily run Winetricks commands for Steam Play/Proton games among other common Wine features,
        such as launching external Windows executables. This is often useful when a game requires closed-source runtime libraries or applications
        that are not included with Proton.</p>
   </description>

--- a/data/com.github.Matoking.protontricks.metainfo.xml
+++ b/data/com.github.Matoking.protontricks.metainfo.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="console-application">
   <id>com.github.Matoking.protontricks</id>
-  <extends>com.valvesoftware.Steam</extends>
   <name>protontricks</name>
-  <summary>A simple wrapper that does winetricks things for Proton enabled games.</summary>
-  <summary xml:lang="pt_BR">Um invólucro simples que executa truques de winetricks para jogos habilitados para usar o Proton.</summary>
-  <summary xml:lang="es">Un contenedor simple que realiza trucos de winetricks para juegos habilitados para usar Proton.</summary>
+  <summary>A simple wrapper that does winetricks things for Proton enabled games</summary>
+  <summary xml:lang="pt_BR">Um invólucro simples que executa truques de winetricks para jogos habilitados para usar o Proton</summary>
+  <summary xml:lang="es">Un contenedor simple que realiza trucos de winetricks para juegos habilitados para usar Proton</summary>
+  <icon type="stock">wine</icon>
+  <provides>
+    <binary>protontricks</binary>
+  </provides>
+  <recommends>com.valvesoftware.Steam</recommends>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://raw.githubusercontent.com/Matoking/protontricks/master/data/screenshot.png</image>
@@ -14,7 +18,9 @@
   </screenshots>
   <content_rating type="oars-1.1"/>
   <description>
-    <p>A simple wrapper that does winetricks things for Proton enabled games.</p>
+    <p>This is a wrapper script that allows you to easily run Winetricks commandsfor Steam Play/Proton games among other common Wine features,
+       such as launching external Windows executables. This is often useful when a game requires closed-source runtime libraries or applications
+       that are not included with Proton.</p>
   </description>
   <url type="homepage">https://github.com/Matoking/protontricks/wiki</url>
   <url type="help">https://github.com/Matoking/protontricks/wiki</url>


### PR DESCRIPTION
Debian reported several issues with the AppStream file: https://appstream.debian.org/sid/contrib/issues/protontricks.html

You can check them yourself by running `appstreamcli validate --pedantic data/com.github.Matoking.protontricks.metainfo.xml`. The output before this PR:
```
$ appstreamcli validate --pedantic ./com.github.Matoking.protontricks.metainfo.xml 
I: com.github.Matoking.protontricks:7: summary-has-dot-suffix
     Um invólucro simples que executa truques de winetricks para jogos habilitados para usar o
     Proton.
I: com.github.Matoking.protontricks:6: summary-has-dot-suffix
     A simple wrapper that does winetricks things for Proton enabled games.
P: com.github.Matoking.protontricks:3: cid-contains-uppercase-letter
     com.github.Matoking.protontricks
I: com.github.Matoking.protontricks:8: summary-has-dot-suffix
     Un contenedor simple que realiza trucos de winetricks para juegos habilitados para usar
     Proton.
I: com.github.Matoking.protontricks:17: description-first-para-too-short
     A simple wrapper that does winetricks things for Proton enabled games.
E: com.github.Matoking.protontricks:~: extends-not-allowed
W: com.github.Matoking.protontricks:~: console-app-no-binary

Validation failed: errors: 1, warnings: 1, infos: 4, pedantic: 1
```
After this PR:
```
$ appstreamcli validate --pedantic data/com.github.Matoking.protontricks.metainfo.xml 
P: com.github.Matoking.protontricks:3: cid-contains-uppercase-letter
     com.github.Matoking.protontricks

Validation was successful: pedantic: 1
```

I get why the `extends` tag is wanted, however this is not how it is defined in the spec. It is *only* for addons, which also must be denoted as `type="addon"`. Better would be something like `enhances`, but this is not present in the spec. Instead I added Steam as `recommends`, which still shows Steam in the Store and does not break the spec.
I also added and icon like in the desktop file and fixed other minor things.
