### PR TITLE
Add Comment and Keywords to desktop file

### DIFF
--- a/src/protontricks/data/protontricks.desktop
+++ b/src/protontricks/data/protontricks.desktop
@@ -1,7 +1,9 @@
 [Desktop Entry]
 Exec=protontricks --no-term --gui
 Name=Protontricks
+Comment=A simple wrapper that does winetricks things for Proton enabled games
 Type=Application
 Terminal=false
 Categories=Utility;
 Icon=wine
+Keywords=Steam;Proton;Wine;Winetricks;


### PR DESCRIPTION
Similar to #127 this was reported during Debian packaging, it adds a comment for the desktop file and some keywords (i.e. when you search your apps for proton or steam, protontricks will also appear in the list).