### PR TITLE
Add Pillow to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 vdf==3.4
+Pillow


### PR DESCRIPTION
5394b3c144edb39c2cd08e6105c3341d1d27cee9 imports PIL (aka Pillow), but did not add it to `requirements.txt`.  This commit fixes this.