### PR TITLE
CLI  Launch: Shlex executable path

### DIFF
--- a/src/protontricks/cli/launch.py
+++ b/src/protontricks/cli/launch.py
@@ -176,7 +176,7 @@ def main(args=None):
         cli_args += ["--no-term"]
 
     inner_args = " ".join(
-        ["wine", f"'{executable_path}'"]
+        ["wine", shlex.quote(str(executable_path))]
         + exec_args
     )
 


### PR DESCRIPTION
If an executable path has a single quote (') in it, it can now be launched.