### PR TITLE
tests: Clear XDG environment variables in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,8 @@ def default_env(monkeypatch):
     """
     monkeypatch.setenv("STEAM_RUNTIME", "")
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.delenv("XDG_DATA_HOME", raising=False)
 
     monkeypatch.setattr("protontricks.steam.COMMON_COMPAT_TOOL_DIRS", [])
 


### PR DESCRIPTION
Clear XDG_CACHE_HOME and XDG_DATA_HOME in the default test environment
to prevent host environment variables from leaking into tests.

This fixes path assertion failures when these variables are set on the
host system, as Protontricks uses them to determine cache and data
locations even when HOME is mocked.
